### PR TITLE
Add model for BC choice in parameter file

### DIFF
--- a/darcy.h
+++ b/darcy.h
@@ -82,6 +82,7 @@ namespace darcy
     unsigned int n_refinements;
     std::string  npy_input_file_path;
     std::string  output_file_prefix;
+    std::string  bc_model;
 
     dealii::ParameterHandler &prm;
 

--- a/darcy_general.h
+++ b/darcy_general.h
@@ -32,6 +32,7 @@
 #include <deal.II/lac/trilinos_sparsity_pattern.h>
 #include <deal.II/lac/vector_operation.h>
 #include <deal.II/numerics/vector_tools.h>
+#include <utility>
 
 #include "darcy.h"
 #include "npy.hpp"
@@ -94,7 +95,7 @@ namespace darcy
     prm.enter_subsection("File input and output");
     {
       npy_input_file_path = prm.get("Numpy input file path");
-      output_file_prefix = prm.get("Output file prefix");
+      output_file_prefix  = prm.get("Output file prefix");
       // data_out.parse_parameters(prm);
     }
     prm.leave_subsection();
@@ -111,6 +112,8 @@ namespace darcy
       degree_u = 1 + degree_p;
     }
     prm.leave_subsection();
+
+    bc_model = prm.get("Model choice");
   }
 
   // ------ read input file ------------------------------
@@ -147,13 +150,16 @@ namespace darcy
   class PressureBoundaryValues : public dealii::Function<dim>
   {
   public:
-    PressureBoundaryValues()
+    PressureBoundaryValues(std::string model)
       : dealii::Function<dim>(1)
+      , model(std::move(model))
     {}
 
     double
     value(const dealii::Point<dim> &p,
           const unsigned int        component = 0) const override;
+
+    std::string model;
   };
 
   template <int dim>
@@ -161,11 +167,25 @@ namespace darcy
   PressureBoundaryValues<dim>::value(const dealii::Point<dim> &p,
                                      const unsigned int /*component*/) const
   {
-    return 1 - p[0] * p[0] + (p[1] - 0.5) * (p[1] - 0.5); // HF model
-    // return 1 - 0.75*p[0]; // LF pressure BC for bad model
-    // return 1 - p[0] + std::abs(p[1] - 0.5);  // LF pressure for moderate
-    // model
+    if (model == "HF")
+      {
+        return 1 - p[0] * p[0] + (p[1] - 0.5) * (p[1] - 0.5); // HF model
+      }
+    else if (model == "LFb")
+      {
+        return 1 - 0.75 * p[0]; // LF pressure BC for bad model
+      }
+    else if (model == "LFm")
+      {
+        return 1 - p[0] +
+               std::abs(p[1] - 0.5); // LF pressure for moderate model
+      }
+    else
+      {
+        throw dealii::ExcMessage("Unknown pressure boundary model.");
+      }
 
+    // @jnitzler not sure what these are
     // return 1 - p[0] * p[0] + (0.25 * std::sin(p[1])); // HF pressure BC
     // return p[1] * p[1] + 1; // LF pressure BC lung example
   }
@@ -216,6 +236,7 @@ namespace darcy
             cell->get_dof_indices(local_dof_indices);
 
             // TODO! check if unused is correct
+            // @jnitzler can you check this again please?
             const dealii::FEValuesExtractors::Vector velocities(0);
             const dealii::FEValuesExtractors::Scalar pressure(dim);
 
@@ -312,6 +333,7 @@ namespace darcy
     dealii::FullMatrix<double> local_matrix(dofs_per_cell, dofs_per_cell);
     dealii::Vector<double>     local_rhs(dofs_per_cell);
     // TODO! check if unused is correct
+    // @jnitzler can you check this again please?
     double JxW_q;
 
     // start the cell loop
@@ -335,7 +357,8 @@ namespace darcy
             local_rhs    = 0;
 
             std::vector<double>               boundary_values(n_face_q_points);
-            const PressureBoundaryValues<dim> pressure_boundary_values;
+            const PressureBoundaryValues<dim> pressure_boundary_values(
+              bc_model);
 
             // get rf function values and permeability tensor per cell
             // note we assume the same quadrature points for random field and

--- a/darcy_general.h
+++ b/darcy_general.h
@@ -184,10 +184,6 @@ namespace darcy
       {
         throw dealii::ExcMessage("Unknown pressure boundary model.");
       }
-
-    // @jnitzler not sure what these are
-    // return 1 - p[0] * p[0] + (0.25 * std::sin(p[1])); // HF pressure BC
-    // return p[1] * p[1] + 1; // LF pressure BC lung example
   }
 
   // ------------- assemble approx Schur complement --------------

--- a/parameter_reader.cpp
+++ b/parameter_reader.cpp
@@ -47,7 +47,7 @@ ParameterReader::declare_parameters()
 
   prm.declare_entry("Model choice",
                     "HF",
-                    dealii::Patterns::Anything(),
+                    dealii::Patterns::Selection("HF|LFb|LFm"),
                     "Model choice for BCs: HF, LFb, or LFm");
 }
 

--- a/parameter_reader.cpp
+++ b/parameter_reader.cpp
@@ -44,6 +44,11 @@ ParameterReader::declare_parameters()
                       "Degree of the polynomial approximation for pressure");
   }
   prm.leave_subsection();
+
+  prm.declare_entry("Model choice",
+                    "HF",
+                    dealii::Patterns::Anything(),
+                    "Model choice for BCs: HF, LFb, or LFm");
 }
 
 void

--- a/parameters_example.json
+++ b/parameters_example.json
@@ -8,5 +8,6 @@
   },
   "Finite element parameters": {
     "Pressure polynomial degree": 1
-  }
+  },
+  "Model choice": "LFb"
 }


### PR DESCRIPTION
I added the `bc_model` as a choice for the boundary conditions into the parameter file. 

@jnitzler There are two more BC definitions that were commented out and I did not understand. Can you have a look?

Also, I marked some lines that still have unused variable definitions. Apparently, we forgot to check them before. I guess we can take care of that in this PR, too.